### PR TITLE
fix: Sort SALN records by year descending

### DIFF
--- a/app/routes/official.$slug.tsx
+++ b/app/routes/official.$slug.tsx
@@ -26,6 +26,10 @@ export async function loader({ params }: Route.LoaderArgs) {
     getSALNRecordsForOfficial(official.id)
   ]);
   
+  salnRecords.sort((a, b) => {
+    return b.year - a.year;
+  });
+  
   return { official, officialWithSALN, salnRecords };
 }
 


### PR DESCRIPTION
Issue: Fetched SALN records are not sorted properly
<img width="989" height="793" alt="image" src="https://github.com/user-attachments/assets/9664a02c-4bae-4bae-9366-7e0a2e5373f0" />

**Pages Affected:**
- app\routes\official.$slug.tsx

**Change:**
- Now sorts SALN records by year descending

**Additional Notes:**
- A fix was applied client-side to resolve this generally, though the root issue is in saln-records.json.
- Maybe add sorting button functionality in the future(?)
