### PR TITLE
refactor: Renamed record count label on SALN cards for improved clarity.

### DIFF
--- a/app/components/OfficialsGrid.tsx
+++ b/app/components/OfficialsGrid.tsx
@@ -198,8 +198,8 @@ export function OfficialsGrid({ officials }: OfficialsGridProps) {
                   <div className="mt-auto">
                     {/* Records Count */}
                     <div className="pb-3 border-t border-gray-100">
-                      <div className="flex items-center gap-2 text-sm pt-3">
-                        <span className="text-gray-500">Available Records:</span>
+                      <div className="flex items-center justify-between text-sm pt-3">
+                        <span className="text-gray-500">Available Records</span>
                         <span className="font-semibold text-gray-900">{official.saln_count}</span>
                       </div>
                     </div>


### PR DESCRIPTION
**UI Enhancement**
<img width="597" height="971" alt="image" src="https://github.com/user-attachments/assets/aaa831e1-5ec7-4e3d-8d7b-50f358d0dd2f" />

This should improve clarity and layout of the SALN card footer by:
1. Renaming the data count label to "Available Records."
2. Displaying the count immediately next to the label on a single line (Improves readability especially for larger screens).
